### PR TITLE
Add support of trailing comma in paramaters macros

### DIFF
--- a/packstream/src/lib.rs
+++ b/packstream/src/lib.rs
@@ -313,4 +313,8 @@ macro_rules! parameters(
             map
         }
     };
+
+    { $($key:expr => $value:expr,)* } => {
+        $crate::parameters!($($key => $value),*)
+    }
 );


### PR DESCRIPTION
Hey @redmannequin, You have accomplished a great work in relation to the origin.

This changes allows us to use `parameters!` with the comma at the end of a parameter list.
It looks like a native method we need to support.

```rust
	parameters!(
		"a" => 1,
		"b" => 2,
	)
```